### PR TITLE
Feature Cast Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+## 2.4.1
+
+### ✨ New: Custom Casting Adapter with `.cast()`
+
+You can now easily create **custom adapters on-the-fly** for types that can be encoded into a native type (`int`, `double`, `bool`, `String`) using the new `.cast()` factory on `Prf`.
+
+This allows you to persist your custom objects without writing a full adapter class, by just providing encode/decode functions.
+
+### Example
+
+Let's say you want to store a `Locale` as an `String` (milliseconds):
+
+```dart
+final langPref = Prf.cast<Locale, String>(
+  'saved_language',
+  encode: (locale) => locale.languageCode,
+  decode: (string) => string == null ? null : Locale(string),
+);
+```
+
+### ✨ New: `getOrDefault()` extension method
+
+Added a new method to all `prf` values:
+
+```dart
+Future<T> getOrDefault()
+```
+
+Returns the value from SharedPreferences, or throws an exception if it's `null` and no default was defined.
+
+#### Example:
+
+```dart
+final coins = 'coins'.prf<int>(defaultValue: 0);
+print(await coins.getOrDefault()); // → 0
+
+final level = 'level'.prf<int>(); // no default
+print(await level.getOrDefault()); // ❌ throws if not set
+```
+
+This improves error visibility in logic that assumes a non-null value must exist.
+
+### Technical Details
+
+- Introduced `EncodedDelegateAdapter<T, TCast>`: a flexible adapter that delegates encoding/decoding to provided functions.
+- `.cast<T, TCast>()` factory wraps this adapter for ergonomic, type-safe usage.
+- Compatible with all existing `prf` features (caching, isolated, custom defaults).
+
 ## 2.4.0
 
 We are officially **deprecating all persistent utility services** (trackers and limiters) from the `prf` package. To keep `prf` focused purely on **persistence** (without embedded logic), all advanced time-based utilities are being migrated to two new dedicated packages:

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ This works exactly the same — just a stylistic preference if you like chaining
 - **`isNull()`** → returns `true` if the value is `null`
 - **`getOrFallback(fallback)`** → returns the value or a fallback if `null`
 - **`existsOnPrefs()`** → checks if the key exists in storage
+- **`getOrDefault()`** → returns the value, or throws if no value exists and no default is defined (safe alternative to assuming non-null values)
 
 ---
 

--- a/lib/adapters/encoded_delegate.dart
+++ b/lib/adapters/encoded_delegate.dart
@@ -1,0 +1,40 @@
+import 'package:prf/prf.dart';
+
+/// A function type that defines how to decode a stored string into an object of type [T].
+typedef DecodeFunction<T, TStored> = T? Function(TStored? stored);
+
+/// A function type that defines how to encode an object of type [T] into a string.
+typedef EncodeFunction<T, TStored> = TStored Function(T value);
+
+/// A generic adapter for encoding and decoding objects of type [T] to and from a storage type [TStore].
+///
+/// This class extends [PrfEncodedAdapter] and allows for custom encoding and decoding
+/// logic to be provided via [decodeFunc] and [encodeFunc]. It is useful for cases where
+/// the default encoding/decoding logic does not suffice or when dealing with custom types.
+class EncodedDelegateAdapter<T, TStore> extends PrfEncodedAdapter<T, TStore> {
+  /// The function used to decode a stored value of type [TStore] into an object of type [T].
+  final DecodeFunction<T, TStore> decodeFunc;
+
+  /// The function used to encode an object of type [T] into a value of type [TStore].
+  final EncodeFunction<T, TStore> encodeFunc;
+
+  /// Creates a new instance of [EncodedDelegateAdapter] with the provided encoding and decoding functions.
+  ///
+  /// - [decodeFunc]: A function that takes a [TStore] and returns an object of type [T] or null.
+  /// - [encodeFunc]: A function that takes an object of type [T] and returns a [TStore].
+  const EncodedDelegateAdapter(
+    super._storingAdapter, {
+    required this.decodeFunc,
+    required this.encodeFunc,
+  });
+
+  @override
+  T? decode(TStore? stored) {
+    return decodeFunc(stored);
+  }
+
+  @override
+  TStore encode(T value) {
+    return encodeFunc(value);
+  }
+}

--- a/lib/core/extensions.dart
+++ b/lib/core/extensions.dart
@@ -38,4 +38,14 @@ extension PrfOperationExtensions<T> on BasePrfObject<T> {
   Future<bool> existsOnPrefs() async {
     return await PrfService.instance.containsKey(key);
   }
+
+  /// Retrieves the stored value or throws an exception if no default value is defined.
+  Future<T> getOrDefault() async {
+    final value = await get(); // for type safety
+    if (value != null) {
+      return value;
+    }
+    throw Exception(
+        'Default value not defined for preference of type $T with key $key');
+  }
 }

--- a/lib/prf.dart
+++ b/lib/prf.dart
@@ -75,3 +75,4 @@ export 'core/prf_service.dart';
 export 'deprecated/deprecated.dart';
 export 'types/prf.dart';
 export 'types/prf_iso.dart';
+export 'types/string_extensions.dart';

--- a/lib/prf.dart
+++ b/lib/prf.dart
@@ -64,7 +64,7 @@ export 'adapters/list/num.dart';
 export 'adapters/list/uri.dart';
 export 'adapters/list_binary.dart';
 export 'adapters/native_adapters.dart';
-export 'types/string_extensions.dart';
+export 'adapters/encoded_delegate.dart';
 export 'core/base_adapter.dart';
 export 'core/base_object.dart';
 export 'core/base_service_object.dart';

--- a/lib/types/prf.dart
+++ b/lib/types/prf.dart
@@ -171,6 +171,36 @@ class Prf<T> extends CachedPrfObject<T> {
     );
   }
 
+  /// Creates a new preference for an object that can be encoded and decoded using custom functions.
+  ///
+  /// This factory method initializes a [Prf] instance using an [EncodedDelegateAdapter]
+  /// to handle the conversion between the object and its encoded representation.
+  ///
+  /// - [key]: The key under which the preference is stored.
+  /// - [encode]: A function that converts an instance of type [T] to a representation of type [TCast].
+  /// - [decode]: A function that converts a representation of type [TCast] back to an instance of type [T].
+  /// - [defaultValue]: The default value to use if no stored value exists for the key.
+  ///
+  /// This method is ideal for objects that require custom serialization logic, providing
+  /// flexibility in how objects are stored and retrieved from persistent storage.
+  static Prf<T> cast<T, TCast>(
+    String key, {
+    required EncodeFunction<T, TCast> encode,
+    required DecodeFunction<T, TCast> decode,
+    T? defaultValue,
+  }) {
+    final castAdapter = PrfAdapterMap.instance.of<TCast>();
+    final adapter = EncodedDelegateAdapter<T, TCast>(
+      castAdapter,
+      encodeFunc: encode,
+      decodeFunc: decode,
+    );
+    return adapter.prf(
+      key,
+      defaultValue: defaultValue,
+    );
+  }
+
   /// Creates an isolate-safe version of this preference.
   ///
   /// Returns a [PrfIso] instance that shares the same key, adapter, and default value

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: prf
 description: "Easily save and load values locally. Effortless local persistence with type safety and zero boilerplate. Just get, set, and go. Drop-in replacement for raw SharedPreferences."
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/jozzzzep/prf
 repository: https://github.com/jozzzzep/prf
 issue_tracker: https://github.com/jozzzzep/prf/issues


### PR DESCRIPTION
### ✨ New: Custom Casting Adapter with `.cast()`

You can now easily create **custom adapters on-the-fly** for types that can be encoded into a native type (`int`, `double`, `bool`, `String`) using the new `.cast()` factory on `Prf`.

This allows you to persist your custom objects without writing a full adapter class, by just providing encode/decode functions.

### Example

Let's say you want to store a `Locale` as an `String` (milliseconds):

```dart
final langPref = Prf.cast<Locale, String>(
  'saved_language',
  encode: (locale) => locale.languageCode,
  decode: (string) => string == null ? null : Locale(string),
);
```

### ✨ New: `getOrDefault()` extension method

Added a new method to all `prf` values:

```dart
Future<T> getOrDefault()
```

Returns the value from SharedPreferences, or throws an exception if it's `null` and no default was defined.

#### Example:

```dart
final coins = 'coins'.prf<int>(defaultValue: 0);
print(await coins.getOrDefault()); // → 0

final level = 'level'.prf<int>(); // no default
print(await level.getOrDefault()); // ❌ throws if not set
```

This improves error visibility in logic that assumes a non-null value must exist.

### Technical Details

- Introduced `EncodedDelegateAdapter<T, TCast>`: a flexible adapter that delegates encoding/decoding to provided functions.
- `.cast<T, TCast>()` factory wraps this adapter for ergonomic, type-safe usage.
- Compatible with all existing `prf` features (caching, isolated, custom defaults).